### PR TITLE
allow system installed scripts to be tested

### DIFF
--- a/t/fret.t
+++ b/t/fret.t
@@ -3,7 +3,18 @@
 use Test::Simple tests => 1;
 use File::Compare;
 
-system($^X, "scripts/fret", "-d", "1000000000", "t/testfont.ttf");
+$fret = "scripts/fret";
+
+if (-f $fret)
+{
+    print "Testing scripts in source directory\n";
+}
+else {
+    $fret = "/usr/bin/fret";
+    print "Testing installed scripts in /usr/bin";
+}
+
+system($^X, $fret, "-d", "1000000000", "t/testfont.ttf");
 $res = compare("t/testfont.pdf", "t/base/testfont.pdf");
 #ok (!$res);
 ok(1);

--- a/t/psfix.t
+++ b/t/psfix.t
@@ -3,13 +3,23 @@
 use Test::Simple tests => 2;
 use File::Compare qw( compare compare_text );
 
-system($^X, "scripts/psfix", "t/schtest.ttf", "t/temp.ttf");
+$psfix = "scripts/psfix";
+$dumpfont = "scripts/dumpfont";
+
+if (!-f $psfix)
+{
+    $psfix = "/usr/bin/psfix";
+    $dumpfont = "/usr/bin/dumpfont";
+}
+
+
+system($^X, $psfix, "t/schtest.ttf", "t/temp.ttf");
 $res = compare("t/temp.ttf", "t/base/psfix.ttf");
 ok(!$res);
 unlink "t/temp.ttf" unless ($res);
 
-system($^X, "scripts/psfix", "-s", "t/schtest.ttf", "t/temp_s.ttf");
-my $p = `"$^X" scripts/dumpfont -t post t/temp_s.ttf`;
+system($^X, $psfix, "-s", "t/schtest.ttf", "t/temp_s.ttf");
+my $p = `"$^X" $dumpfont -t post t/temp_s.ttf`;
 $res = ($p !~ /"FormatType" => 3/) || ($p !~ /"VAL" => \[]/);
 ok(!$res);
 unlink "t/temp_s.ttf" unless ($res);

--- a/t/ttfbuilder.t
+++ b/t/ttfbuilder.t
@@ -3,13 +3,22 @@
 use Test::Simple tests => 3;
 use File::Compare qw( compare compare_text );
 
-system($^X, "scripts/ttfbuilder", "-d", "1", "-c", "t/testfont_1.xml", "-z", "t/temp.xml", "t/testfont.ttf", "t/temp.ttf");
+$ttfbuilder = "scripts/ttfbuilder";
+$add_classes = "scripts/add_classes";
+
+if (!-f $ttfbuilder)
+{
+    $ttfbuilder = "/usr/bin/ttfbuilder";
+    $add_classes = "/usr/bin/add_classes";
+}
+
+system($^X, $ttfbuilder, "-d", "1", "-c", "t/testfont_1.xml", "-z", "t/temp.xml", "t/testfont.ttf", "t/temp.ttf");
 $res = compare("t/temp.ttf", "t/base/test_builder.ttf");
 ok(!$res);
 unlink "t/temp.ttf" unless ($res);
 $res = compare_text("t/temp.xml", "t/base/test_builder.xml", \&cmptxtline);
 ok(!$res);
-system($^X, "scripts/add_classes", "-c", "t/testclasses.xml", "t/temp.xml", "t/temp1.xml");
+system($^X, $add_classes, "-c", "t/testclasses.xml", "t/temp.xml", "t/temp1.xml");
 $res = compare_text("t/temp1.xml", "t/base/test_classes.xml", \&cmptxtline);
 ok(!$res);
 unlink "t/temp.xml", "t/temp1.xml" unless ($res);

--- a/t/ttfname.t
+++ b/t/ttfname.t
@@ -3,7 +3,14 @@
 use Test::Simple tests => 1;
 use File::Compare;
 
-system($^X, "scripts/ttfname", "-n", "Tested FontUtils", "t/testfont.ttf", "t/temp.ttf");
+$ttfname = "scripts/ttfname";
+
+if (!-f $ttfname)
+{
+    $ttfname = "/usr/bin/ttfname";
+}
+
+system($^X, $ttfname, "-n", "Tested FontUtils", "t/testfont.ttf", "t/temp.ttf");
 $res = compare("t/temp.ttf", "t/base/ttfnamed.ttf");
 ok(!$res);
 unlink "t/temp.ttf" unless ($res);

--- a/t/ttfsubset.t
+++ b/t/ttfsubset.t
@@ -3,7 +3,14 @@
 use Test::Simple tests => 2;
 use File::Compare;
 
-$res = system($^X, 'scripts/ttfsubset', '-g', 't/subset.cfg', '-n', 'Subset', 't/testfont.ttf', 't/subset.ttf');
+$ttfsubset = "scripts/ttfsubset";
+
+if (!-f $ttfsubset)
+{
+    $ttfsubset = "/usr/bin/ttfsubset";
+}
+
+$res = system($^X, $ttfsubset, '-g', 't/subset.cfg', '-n', 'Subset', 't/testfont.ttf', 't/subset.ttf');
 ok (!($res>>8), "exit code");
 $res = compare("t/subset.ttf", "t/base/subset.ttf");
 ok(!$res, "compiled.ttf");

--- a/t/typetuner.t
+++ b/t/typetuner.t
@@ -13,19 +13,28 @@ use Test::Simple tests => 7;
 use File::Compare qw( compare compare_text );
 use File::Copy; #move func
 
+$typetuner = "scripts/typetuner";
+$ttftable = "scripts/ttftable";
+
+if (!-f $typetuner)
+{
+    $typetuner = "/usr/bin/typetuner";
+    $ttftable = "/usr/bin/ttftable";
+}
+
 # set $debug to true to run TypeTuner in debug mode and visually separate test output
 my $debug = 0;
 if ($debug) 
-	{@run_tt = ("$^X", "scripts/typetuner", "-d");}
+	{@run_tt = ("$^X", $typetuner, "-d");}
 else
-	{@run_tt = ("$^X", "scripts/typetuner");}
+	{@run_tt = ("$^X", $typetuner);}
              
 # add Features file to font to make a Tuner-ready font
-#system($^X, "scripts/typetuner", "-d", "add", "t/tt_feat_all.xml", "t/tt_font.ttf");
+#system($^X, $typetuner, "-d", "add", "t/tt_feat_all.xml", "t/tt_font.ttf");
 system(@run_tt, "add", "t/tt_feat_all.xml", "t/tt_font.ttf");
 #$res_ttf = compare("t/tt_font_tt.ttf", "t/base/tt_font_tt.ttf"); #compare to list of tables instead
-#system($^X, "scripts/ttftable", "-list", "t/tt_font_tt.ttf", ">" ,"t/tt_font_tt.ttf.list.dat"); ### ttftable isn't called correctly
-$tbl_list = `$^X scripts/ttftable -list t/tt_font_tt.ttf`;
+#system($^X, $ttftable, "-list", "t/tt_font_tt.ttf", ">" ,"t/tt_font_tt.ttf.list.dat"); ### ttftable isn't called correctly
+$tbl_list = `$^X $ttftable -list t/tt_font_tt.ttf`;
 $res_ttf = ($tbl_list =~ /Silt/);
 ok($res_ttf, "added Feature file to font");
 print "****\n\n" if $debug;
@@ -47,10 +56,10 @@ print "****\n\n" if $debug;
 #     processing the settings exercises the cmds in the Features file
 system(@run_tt, "-o", "t/tt_font_tt_1_metrics.ttf", "applyset", "t/tt_feat_set_1_metrics.xml", "t/tt_font_tt.ttf");
 # $res = compare("t/tt_font_tt_1.ttf", "t/base/tt_font_tt_1_metrics.ttf"); ### fails because of internal time stamp
-# system($^X, "scripts/ttftable", "-export", "Feat,GSUB,GPOS,cmap,name", "t/tt_font_tt_1_metrics.ttf");
+# system($^X, $ttftable, "-export", "Feat,GSUB,GPOS,cmap,name", "t/tt_font_tt_1_metrics.ttf");
 foreach my $tag (qw(Feat GSUB GPOS cmap name)) {
-	system($^X, "scripts/ttftable", "-export", "$tag", "t/tt_font_tt_1_metrics.ttf");
-#	system($^X, "scripts/ttftable", "-export", "$tag", "t/base/tt_font_tt_1_metrics.ttf"); #uncomment to create dump files from new base font
+	system($^X, $ttftable, "-export", "$tag", "t/tt_font_tt_1_metrics.ttf");
+#	system($^X, $ttftable, "-export", "$tag", "t/base/tt_font_tt_1_metrics.ttf"); #uncomment to create dump files from new base font
 }
 $res = compare("t/tt_font_tt_1_metrics.ttf.Feat.dat", "t/base/tt_font_tt_1_metrics.ttf.Feat.dat") ||
 	compare("t/tt_font_tt_1_metrics.ttf.GSUB.dat", "t/base/tt_font_tt_1_metrics.ttf.GSUB.dat") ||
@@ -73,8 +82,8 @@ print "****\n\n" if $debug;
 #     processing the settings exercises some different cmds in the Features file
 system(@run_tt, "-o", "t/tt_font_2.ttf", "applyset_xml", "t/tt_feat_all.xml", "t/tt_feat_set_2.xml", "t/tt_font.ttf");
 foreach my $tag (qw(Feat GSUB GPOS cmap name)) {
-	system($^X, "scripts/ttftable", "-export", "$tag", "t/tt_font_2.ttf");
-#	system($^X, "scripts/ttftable", "-export", "$tag", "t/base/tt_font_2.ttf");
+	system($^X, $ttftable, "-export", "$tag", "t/tt_font_2.ttf");
+#	system($^X, $ttftable, "-export", "$tag", "t/base/tt_font_2.ttf");
 }
 $res = compare("t/tt_font_2.ttf.Feat.dat", "t/base/tt_font_2.ttf.Feat.dat") ||
 	compare("t/tt_font_2.ttf.GSUB.dat", "t/base/tt_font_2.ttf.GSUB.dat") ||
@@ -98,8 +107,8 @@ print "****\n\n" if $debug;
 
 # delete the Settings file from a tuned font
 system(@run_tt, "delete", "t/tt_font_2.ttf");
-$tbl_list_1 = `$^X scripts/ttftable -list t/tt_font_2.ttf`;
-$tbl_list_2 = `$^X scripts/ttftable -list t/tt_font_2_tt.ttf`;
+$tbl_list_1 = `$^X $ttftable -list t/tt_font_2.ttf`;
+$tbl_list_2 = `$^X $ttftable -list t/tt_font_2_tt.ttf`;
 $res = (($tbl_list_1 =~ /Silt/) && ($tbl_list_2 !~ /Silt/));
 ok($res, "deleted the Settings file from a tuned font");
 unlink "t/tt_font_2.ttf" unless (!$res);

--- a/t/volt2ttf.t
+++ b/t/volt2ttf.t
@@ -3,13 +3,20 @@
 use Test::Simple tests => 4;
 use File::Compare;
 
-$res = system($^X, 'scripts/volt2ttf', '-t', 't/schtest.vtp', 't/schtest.ttf', 't/compiled.ttf');
+$volt2ttf = "scripts/volt2ttf";
+
+if (!-f $volt2ttf)
+{
+    $volt2ttf = "/usr/bin/volt2ttf";
+}
+
+$res = system($^X, $volt2ttf, '-t', 't/schtest.vtp', 't/schtest.ttf', 't/compiled.ttf');
 ok (!($res>>8), "exit code");
 $res = compare("t/compiled.ttf", "t/base/compiled.ttf");
 ok(!$res, "compiled.ttf");
 unlink "t/compiled.ttf" unless ($res);
 
-$res = system($^X, 'scripts/volt2ttf', '-t', 't/lamalefliga.vtp', 't/schtest.ttf', 't/lamalefliga.ttf');
+$res = system($^X, $volt2ttf, '-t', 't/lamalefliga.vtp', 't/schtest.ttf', 't/lamalefliga.ttf');
 ok (!($res>>8), "exit code");
 $res = compare("t/lamalefliga.ttf", "t/base/lamalefliga.ttf");
 ok(!$res, "lamalefliga.ttf");


### PR DESCRIPTION
if you aren't running the tests from the source directory then this will use scripts installed in /usr/bin

This is useful to check that it has been installed properly.
