### PR TITLE
Old examples

### DIFF
--- a/Examples/addpclt.pl
+++ b/Examples/addpclt.pl
@@ -6,8 +6,8 @@
 # 1.0.0 MJPH    18-MAR-1998     Original
 
 require 'ttfmod.pl';
-require 'getopts.pl';
-do Getopts("d:z");
+use Getopt::Std;
+do getopts("d:z");
 
 $[ = 0;
 if ((defined $opt_d && !defined $ARGV[0]) || (!defined $opt_d && !defined $ARGV[1]))

--- a/Examples/makemono.pl
+++ b/Examples/makemono.pl
@@ -6,8 +6,8 @@
 # MJPH  1.0.0   25-MAR-1998     Original
 
 require 'ttfmod.pl';
-require 'getopts.pl';
-&Getopts("d:z");
+use Getopt::Std;
+&getopts("d:z");
 
 if ((defined $opt_d && !defined $ARGV[0]) || (!defined $opt_d && !defined $ARGV[1]))
 {

--- a/Examples/stripcmap.pl
+++ b/Examples/stripcmap.pl
@@ -1,8 +1,8 @@
 #! /usr/bin/perl
 use Font::TTF::Font;
-require 'getopts.pl';
+use Getopt::Std;
 
-Getopts("umws");
+getopts("umws");
 
 unless (defined $ARGV[1])
 {

--- a/Examples/ttfextracttable.pl
+++ b/Examples/ttfextracttable.pl
@@ -2,8 +2,8 @@
 # 1.1   RMH    06-Feb-00     Extract a raw TTF table to a file
 
 use Font::TTF::Font;
-require 'getopts.pl';
-Getopts('at:');
+use Getopt::Std;
+getopts('at:');
 
 unless (defined $ARGV[0])
 {

--- a/Examples/ttfname-old.pl
+++ b/Examples/ttfname-old.pl
@@ -8,8 +8,8 @@
 # 1.1   MJPH    20-MAR-1998     Add -l, -s
 
 require 'ttfmod.pl';
-require 'getopts.pl';
-do Getopts("f:l:n:qs:t:");
+use Getopt::Std;
+do getopts("f:l:n:qs:t:");
 
 
 if (!defined $ARGV[1] || !defined $opt_n)

--- a/Examples/ttfreplacetable.pl
+++ b/Examples/ttfreplacetable.pl
@@ -2,8 +2,8 @@
 # 1.0   RMH    14-Feb-00     Insert a raw TTF table into a font file
 
 use Font::TTF::Font;
-require 'getopts.pl';
-Getopts('d:t:');
+use Getopt::Std;
+getopts('d:t:');
 
 ($inFontFile, $inDataFile, $outFontFile) = @ARGV;
 

--- a/Examples/ttfwidth.pl
+++ b/Examples/ttfwidth.pl
@@ -6,8 +6,8 @@
 #                in either SF or CSV format.
 # 1.2.0     25-MAR-1998     Tidy up to package with the rest
 
-require 'getopts.pl';
-do Getopts("qsuzp:");
+use Getopt::Std;
+getopts("qsuzp:");
 
 if (!defined $ARGV[0])
     {

--- a/Examples/zerohyph.pl
+++ b/Examples/zerohyph.pl
@@ -1,8 +1,8 @@
 #! /usr/bin/perl
-require 'getopts.pl';
+use Getopt::Std;
 use Font::TTF::Font;
 
-Getopts('u:s:');
+getopts('u:s:');
 
 unless (defined $ARGV[1])
 {

--- a/lib/Font/TTF/Scripts/Deflang.pm
+++ b/lib/Font/TTF/Scripts/Deflang.pm
@@ -59,6 +59,11 @@ sub ttfdeflang
 
 1;
 
+=head1 NAME
+
+Font::TTF::Scripts::Deflang - Creates a font with the given language id as being default.
+
+
 =head1 AUTHOR
 
 Martin Hosken L<http://scripts.sil.org/FontUtils>. 

--- a/lib/Font/TTF/Scripts/Fea.pm
+++ b/lib/Font/TTF/Scripts/Fea.pm
@@ -279,6 +279,11 @@ sub end_out
 
 1;
 
+=head1 NAME
+
+Font::TTF::Scripts::Fea - Creates font specific AFDKO fea source file from 
+                          a font and optional attachment point database
+
 =head1 See also
 
 L<Font::TTF::Scripts::AP>

--- a/lib/Font/TTF/Scripts/GDL.pm
+++ b/lib/Font/TTF/Scripts/GDL.pm
@@ -446,6 +446,12 @@ sub has
 
 1;
 
+=head1 NAME
+
+Font::TTF::Scripts::GDL - create GDL (Graphite Description Language) from a
+                          TrueType font
+
+
 =head1 AUTHOR
 
 Martin Hosken L<http://scripts.sil.org/FontUtils>. 

--- a/lib/Font/TTF/Scripts/Name.pm
+++ b/lib/Font/TTF/Scripts/Name.pm
@@ -111,6 +111,10 @@ sub ttfname
 
 1;
 
+=head1 NAME
+
+Font::TTF::Scripts::Name - set name of font
+
 
 =head1 AUTHOR
 

--- a/lib/Font/TTF/Scripts/Thai.pm
+++ b/lib/Font/TTF/Scripts/Thai.pm
@@ -477,6 +477,11 @@ sub cut
 
 1;
 
+=head1 NAME
+
+Font::TTF::Scripts::Thai - handling of legacy (non-Unicode) Thai fonts
+
+
 =head1 AUTHOR
 
 Martin Hosken L<http://scripts.sil.org/FontUtils>. 

--- a/scripts/ttf2volt
+++ b/scripts/ttf2volt
@@ -1719,6 +1719,46 @@ print STDERR $xx;
 
 #])}
 
+=head1 NAME
+
+ttf2volt - create VOLT project from existing OpenType font file
+
+=head1 SYNOPSIS
+
+  ttf2volt [options] infontfile [outfontfile]
+
+Creates a VOLT project from an existing OpenType font file.
+
+=head1 OPTIONS
+
+  -a        allow non-adobe glyph names
+  -g n      group creation threshold
+  -l file   emit log messages to named file
+  -r        retain GPOS, GSUB, and GDEF tables in output font
+  -s        do not send warnings to stdout (will still go to log)
+  -t file   name of replacement VOLT tags file if needed.
+  -v file   Volt project source (.vtp) file to create
+
+=head1 DESCRIPTION
+
+Attempts to create a VOLT project from an existing OpenType font by reading and
+interpreting the existing GDEF, GPOS, and GSUB tables. Not every OpenType
+rule can be mimiced in VOLT; warnings are issued when ttf2volt cannot
+handle something.
+
+In normal usage, specify either outfontfile (to create a font
+ready to be opened by VOLT) and/or the -v option (to create a
+VOLT project source that can be imported into the font).
+    
+The group creation threshold option sets the minimum number of glyphs
+that ttf2volt will put into a group for the purposes of building
+a lookup.
+
+Lookups currently supported  (type[.format]):
+
+GSUB:   1 2 3 4   6.3
+GPOS    1 2 3 4 5     8.3
+
 =head1 AUTHOR
 
 Martin Hosken L<http://scripts.sil.org/FontUtils>.

--- a/scripts/ttfbboxfix
+++ b/scripts/ttfbboxfix
@@ -79,6 +79,25 @@ print "$count bounding box ", ($count == 1 ? "difference" : "differences"), ($AR
 
 $f->out($ARGV[1]) if $ARGV[1];
 
+=head1 NAME
+
+ttfbboxfix - re-calculates bounding boxes for all glyphs in a font
+
+=head1 SYNOPSIS
+
+  ttfbboxfix [-v] in.ttf [out.ttf]
+
+Re-calculates bounding boxes for all glyphs in a font.
+
+=head1 OPTIONS
+
+  -v verbose output to stdout
+
+=head1 DESCRIPTION
+
+Re-calculates bounding boxes for all glyphs in a font. 
+if <outfile> is provided, rewrite corrected font.
+
 =head1 AUTHOR
 
 Martin Hosken L<http://scripts.sil.org/FontUtils>.

--- a/scripts/typetuner
+++ b/scripts/typetuner
@@ -1298,6 +1298,59 @@ sub cmd_line_exec(@)
 
 cmd_line_exec(@ARGV);
 
+=head1 NAME
+
+typetuner - create fonts which users can then alter (also using TypeTuner) to 
+            change default glyphs and behaviors.
+
+=head1 SYNOPSIS
+
+	typetuner -x <xml> <ttf> (create settings xml file from ttf)
+	typetuner <xml> <ttf> (apply settings xml file to ttf)
+	
+	or typetuner [<switches>] <command> [files, ...]
+
+Enables font developers to create fonts which users can then alter
+(also using TypeTuner) to change default glyphs and behaviors.
+
+=head1 OPTIONS
+
+  -h - help via the usage message
+  -d - debug output
+  -f - for add & extract subcommands, don't check whether proper element at start of file
+  -t - output feat_set.xml file with all settings at non-default values for testing TypeTuner
+  -m - maximum length of featset suffix for font name
+  -n - string to use a suffix at end of font name instead of featset string
+  -o - name for output font file instead of generating by appending _tt
+  -v - version number (bypasses adding featset suffix to the version)
+  -x - for simplified command line, call createset
+
+=head1 DESCRIPTION
+
+usage: 
+	TypeTuner -x <xml> <ttf> (create settings xml file from ttf)
+	TypeTuner <xml> <ttf> (apply settings xml file to ttf)
+	
+	or TypeTuner [<switches>] <command> [files, ...]
+	
+switches:
+	-m	specify maximum length of generated font name suffix
+	-n	specify font name suffix instead of using generated one
+	-o	specify output font.ttf file name
+
+commands:
+	createset <font.ttf | feat_all.xml> feat_set.xml 
+	
+	setmetrics font_old.ttf feat_set.xml
+	
+	applyset     feat_set.xml font.ttf
+	applyset_xml feat_all.xml feat_set.xml font.ttf
+	
+	extract font.ttf feat_set.xml
+	add     feat_all.xml font.ttf
+	delete  font.ttf
+
+
 =head1 AUTHOR
 
 Alan Ward L<http://scripts.sil.org/FontUtils>.


### PR DESCRIPTION
This changes old examples to use perl5 Getopt::Std rather than deprecated perl4 getopt.pl
